### PR TITLE
fix random invalid non ascii character on ftp get

### DIFF
--- a/src/fileTransferProtocol/ftpRemoteGet.ts
+++ b/src/fileTransferProtocol/ftpRemoteGet.ts
@@ -26,16 +26,17 @@ export function ftpRemoteGet (path: string, settings: SettingsJSON): Thenable<st
                 }
                 else {
                     VSCODE_OUTPUT.appendLine(`\tGet Remote => (${path})`);
+                    stream.setEncoding('utf8');
                     stream.on('data', function (buffer){
                         if (buffer) {
-                            var part = buffer.toString();
+                            var part = buffer;
                             string += part;
                         }
                     });
                 }
                 stream.once('close', function () {
                     remote.end();
-                    resolve(string);
+                    resolve(string.toString());
                 });
             });
         });


### PR DESCRIPTION
steam buffer separate on middle of utf8 binary

example 'ก' is
problem is buffer split on  11100000 10111000 and 10000001
make character invalid 

solution is set stream character encoding to utf8